### PR TITLE
Add Clojurescript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 *~
+/out
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 language: clojure
 sudo: false
 
-script: lein do test, doo once, deploy
+jobs:
+  include:
+    - name: clj tests
+      script: lein test
+    - name: cljs tests
+      script: lein doo once
+    - stage: deploy
+      script: lein deploy
+      if: branch=master AND event=push AND fork=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: clojure
 sudo: false
 
-script: lein do test, deploy
+script: lein do test, doo once, deploy

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :url "http://github.com/acrolinx/clj-queue-by"
   :license {:name "Apache License 2.0"
             :url "http://www.apache.org/licenses/"}
+
   :deploy-repositories [["releases"
                          {:url "https://clojars.org/repo"
                           :password :env/CLOJARS_PASS
@@ -12,4 +13,16 @@
                          {:url "https://clojars.org/repo"
                           :password :env/CLOJARS_PASS
                           :username :env/CLOJARS_USER}]]
-  :dependencies [[org.clojure/clojure "1.8.0"]])
+
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/clojurescript "1.10.520"]]
+
+  :plugins [[lein-doo "0.1.11"]
+            [lein-cljsbuild "1.1.7"]]
+
+  :cljsbuild {:builds {:tests {:source-paths ["src" "test"]
+                               :compiler {:output-to "target/tests.js"
+                                          :main com.acrolinx.cljs-test-runner
+                                          :optimizations :simple}}}}
+  :doo {:build "tests"
+        :alias {:default [:nashorn]}})

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                           :password :env/CLOJARS_PASS
                           :username :env/CLOJARS_USER}]]
 
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.10.520"]]
 
   :plugins [[lein-doo "0.1.11"]

--- a/src/com/acrolinx/clj_queue_by.cljc
+++ b/src/com/acrolinx/clj_queue_by.cljc
@@ -110,14 +110,14 @@
   Mutates internal queue."
   [the-q keyfn max-size it]
 
-  (when max-size
-    (let [cnt (queue-count @the-q)]
-      (when (>= cnt max-size)
-        (throw (ex-info "Queue overflow."
-                        {:item         it
-                         :current-size cnt})))))
   (swap! the-q
          (fn [{:keys [::index] :as q}]
+           (when max-size
+             (let [cnt (queue-count q)]
+               (when (>= cnt max-size)
+                 (throw (ex-info "Queue overflow."
+                                 {:item         it
+                                  :current-size cnt})))))
            (let [new-index (inc index)]
              (-> q
                  (assoc ::index new-index)

--- a/src/com/acrolinx/clj_queue_by.cljc
+++ b/src/com/acrolinx/clj_queue_by.cljc
@@ -22,9 +22,9 @@
 
 #?(:clj
    (defmethod print-method clojure.lang.PersistentQueue
-              [q ^java.io.Writer w]
-              (.write w "#<<")
-              (print-method (sequence q) w))
+     [q ^java.io.Writer w]
+     (.write w "#<<")
+     (print-method (sequence q) w))
 
    :cljs
    (extend-type cljs.core.PersistentQueue
@@ -71,8 +71,8 @@
   map are created with the key-fn which is passed to the
   constructor."
   []
-  {::selected (persistent-empty-queue)
-   ::queued {}
+  {::selected  (persistent-empty-queue)
+   ::queued    {}
    ::the-index 0})
 
 (defn- queue-count
@@ -112,7 +112,7 @@
     (let [cnt (queue-count @the-q)]
       (when (>= cnt max-size)
         (throw (ex-info "Queue overflow."
-                        {:item it
+                        {:item         it
                          :current-size cnt})))))
   (swap! the-q
          (fn [{:keys [::the-index] :as q}]
@@ -122,7 +122,7 @@
                  (update-in [::queued (keyfn it)] quonj
                             ;; uses in-transaction value already inced
                             {::data it
-                             ::id new-index}))))))
+                             ::id   new-index}))))))
 
 (defn- pop-from-selected [the-q]
   (let [{:keys [::selected]} @the-q

--- a/src/com/acrolinx/clj_queue_by.cljc
+++ b/src/com/acrolinx/clj_queue_by.cljc
@@ -126,11 +126,9 @@
                              ::id   new-index}))))))
 
 (defn- pop-from-selected [the-q]
-  (let [{:keys [::selected]} @the-q
-        head (peek selected)
-        tail (pop selected)]
-    (swap! the-q assoc ::selected tail)
-    head))
+  (let [{:keys [::selected]} @the-q]
+    (swap! the-q update ::selected pop)
+    (peek selected)))
 
 (defn- peeks-and-pops
   "Returns the snapshot and remainder of the queues in QUEUE-MAP.
@@ -150,7 +148,8 @@
      ::queued   (into {} (filter (fn [[k queue]] (not-empty queue)) tails))}))
 
 (defn- select-snapshot! [the-q]
-  (swap! the-q merge (peeks-and-pops (::queued @the-q))))
+  (swap! the-q (fn [q]
+                 (merge q (peeks-and-pops (::queued q))))))
 
 (defn- queue-pop
   "Pops an item from the queue.

--- a/src/com/acrolinx/clj_queue_by.cljc
+++ b/src/com/acrolinx/clj_queue_by.cljc
@@ -126,9 +126,8 @@
                              ::id   new-index}))))))
 
 (defn- pop-from-selected [the-q]
-  (let [{:keys [::selected]} @the-q]
-    (swap! the-q update ::selected pop)
-    (peek selected)))
+  (let [[old _] (swap-vals! the-q update ::selected pop)]
+    (peek (::selected old))))
 
 (defn- peeks-and-pops
   "Returns the snapshot and remainder of the queues in QUEUE-MAP.

--- a/test/com/acrolinx/clj_queue_by_stress_test.clj
+++ b/test/com/acrolinx/clj_queue_by_stress_test.clj
@@ -1,0 +1,87 @@
+;; Copyright 2017-2018 Acrolinx GmbH
+
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+;; implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns com.acrolinx.clj-queue-by-stress-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [com.acrolinx.clj-queue-by :as tt]))
+
+;; FIXME: I'd feel better to have some real-world multi-threaded test
+;; here and run it a 1000 times or so.
+(deftest queue-multi-threaded-basic-test
+   (let [q (tt/queue-by :core)]
+
+     (testing "Adding many and get them back as expected"
+       (future (q {:core :alice :a :1})
+               (q {:core :bob :a :1})
+               (q {:core :alice :a :2})
+               (q {:core :alice :a :3})
+               (q {:core :bob :a :2})
+               (q {:core :charlie :a :1})
+               (q {:core :charlie :a :2})
+               (q {:core :charlie :a :3})
+               (q {:core :charlie :a :4}))
+
+       ;; wait for the future to start
+       (Thread/sleep 100)
+       ;; all blocking on the deref of the future
+       (is (= {:core :alice :a :1} @(future (q))))
+       (is (= {:core :bob :a :1} @(future (q))))
+       (is (= {:core :charlie :a :1} @(future (q))))
+       (is (= {:core :alice :a :2} @(future (q))))
+       (is (= {:core :bob :a :2} @(future (q))))
+       (is (= {:core :charlie :a :2} @(future (q))))
+       (is (= {:core :alice :a :3} @(future (q))))
+       (is (= {:core :charlie :a :3} @(future (q))))
+       (is (= {:core :charlie :a :4} @(future (q))))
+       (is (= 0 (count q))))))
+
+(defn stress-reader [q max-reads]
+  (let [cnt (atom 0)
+        succ (atom {"t1" 0
+                    "t2" 0
+                    "t3" 0})]
+    (loop [it nil]
+      (swap! cnt inc)
+      (cond
+
+        (< max-reads @cnt)
+        @succ
+
+        (not (nil? it))
+        (do
+          (swap! succ update-in [(:name it)] inc)
+          ;; (printf "<%s" (:id it))
+          (recur (q)))
+
+        :else
+        (do
+          ;; (Thread/sleep 1)
+          (recur (q)))))))
+
+(defn stress-writer [q name n]
+  (dotimes [i n]
+    (q {:name name :id i})
+    ;; (printf ">%s" i)
+    ))
+
+(defn stress-main []
+  (let [q (tt/queue-by :name 2800)
+        r (future (stress-reader q 9000))
+        w1 (future (stress-writer q "t1" 900))
+        w2 (future (stress-writer q "t2" 900))
+        w3 (future (stress-writer q "t3" 900))]
+    (= @r {"t1" 900, "t2" 900, "t3" 900})))
+
+(deftest stress-test
+  (is (stress-main)))

--- a/test/com/acrolinx/clj_queue_by_test.cljc
+++ b/test/com/acrolinx/clj_queue_by_test.cljc
@@ -107,36 +107,6 @@
       (is (= {:core :charlie :a :4} (q)))
       (is (= 0 (count q))))))
 
-;; FIXME: I'd feel better to have some real-world multi-threaded test
-;; here and run it a 1000 times or so.
-(deftest queue-multi-threaded-basic-test
-  (let [q (tt/queue-by :core)]
-
-    (testing "Adding many and get them back as expected"
-      (future (q {:core :alice   :a :1})
-              (q {:core :bob     :a :1})
-              (q {:core :alice   :a :2})
-              (q {:core :alice   :a :3})
-              (q {:core :bob     :a :2})
-              (q {:core :charlie :a :1})
-              (q {:core :charlie :a :2})
-              (q {:core :charlie :a :3})
-              (q {:core :charlie :a :4}))
-
-      ;; wait for the future to start
-      (Thread/sleep 100)
-      ;; all blocking on the deref of the future
-      (is (= {:core :alice   :a :1} @(future (q))))
-      (is (= {:core :bob     :a :1} @(future (q))))
-      (is (= {:core :charlie :a :1} @(future (q))))
-      (is (= {:core :alice   :a :2} @(future (q))))
-      (is (= {:core :bob     :a :2} @(future (q))))
-      (is (= {:core :charlie :a :2} @(future (q))))
-      (is (= {:core :alice   :a :3} @(future (q))))
-      (is (= {:core :charlie :a :3} @(future (q))))
-      (is (= {:core :charlie :a :4} @(future (q))))
-      (is (= 0 (count q))))))
-
 (deftest overflow-test
   (let [q (tt/queue-by :x 2)]
     (testing "No item added"
@@ -202,42 +172,3 @@
             "two" pq}]
           @qb)))))
 
-(defn stress-reader [q max-reads]
-  (let [cnt (atom 0)
-        succ (atom {"t1" 0
-                    "t2" 0
-                    "t3" 0})]
-    (loop [it nil]
-      (swap! cnt inc)
-      (cond
-
-        (< max-reads @cnt)
-        @succ
-
-        (not (nil? it))
-        (do
-          (swap! succ update-in [(:name it)] inc)
-          ;; (printf "<%s" (:id it))
-          (recur (q)))
-
-        :else
-        (do
-          ;; (Thread/sleep 1)
-          (recur (q)))))))
-
-(defn stress-writer [q name n]
-  (dotimes [i n]
-    (q {:name name :id i})
-    ;; (printf ">%s" i)
-    ))
-
-(defn stress-main []
-  (let [q (tt/queue-by :name 2800)
-        r (future (stress-reader q 9000))
-        w1 (future (stress-writer q "t1" 900))
-        w2 (future (stress-writer q "t2" 900))
-        w3 (future (stress-writer q "t3" 900))]
-    (= @r {"t1" 900, "t2" 900, "t3" 900})))
-
-(deftest stress-test
-  (is (stress-main)))

--- a/test/com/acrolinx/clj_queue_by_test.cljc
+++ b/test/com/acrolinx/clj_queue_by_test.cljc
@@ -13,20 +13,23 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns com.acrolinx.clj-queue-by-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest testing is]]
             [com.acrolinx.clj-queue-by :as tt]))
+
 
 (deftest quonj-test
   (let [t #'tt/quonj]
     (testing "Adding to empty"
       (let [it (t nil :x)]
-        (is (= clojure.lang.PersistentQueue
-             (type it)))
+        (is (= #?(:clj clojure.lang.PersistentQueue
+                  :cljs cljs.core.PersistentQueue)
+               (type it)))
         (is (= [:x] it))))
     (testing "Adding repeatedly"
       (let [it1 (t nil :x)
             it2 (t it1 :y)]
-        (is (= clojure.lang.PersistentQueue
+        (is (= #?(:clj clojure.lang.PersistentQueue
+                  :cljs cljs.core.PersistentQueue)
              (type it2)))
         (is (= [:x :y] it2))))))
 

--- a/test/com/acrolinx/clj_queue_by_test.cljc
+++ b/test/com/acrolinx/clj_queue_by_test.cljc
@@ -117,7 +117,8 @@
       (is (= 2 (count q))))
     (testing "Adding more values than allowed"
       (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
+           #?(:clj clojure.lang.ExceptionInfo
+              :cljs cljs.core.ExceptionInfo)
            #"overflow"
            (q {:x 1})))
       (is (= 2 (count q)))))
@@ -125,7 +126,8 @@
     (testing "Adding more values than allowed (default size)"
       (dotimes [i @#'com.acrolinx.clj-queue-by/DEFAULT-QUEUE-SIZE] (q {:x 2}))
       (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
+           #?(:clj clojure.lang.ExceptionInfo
+              :cljs cljs.core.ExceptionInfo)
            #"overflow"
            (q {:x 1})))))
   (let [q (tt/queue-by :x nil)]
@@ -135,7 +137,7 @@
 
 (deftest deref-test
   (let [qb (tt/queue-by :i)
-        pq (clojure.lang.PersistentQueue/EMPTY)]
+        pq (#'com.acrolinx.clj-queue-by/persistent-empty-queue)]
 
     (testing "Empty queue"
       (is (= [pq {}]

--- a/test/com/acrolinx/cljs_test_runner.cljs
+++ b/test/com/acrolinx/cljs_test_runner.cljs
@@ -1,0 +1,5 @@
+(ns com.acrolinx.cljs-test-runner
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [com.acrolinx.clj-queue-by-test]))
+
+(doo-tests 'com.acrolinx.clj-queue-by-test)


### PR DESCRIPTION
Resolves #3 

This PR migrates to .cljc files to add ClojureScript support. The library implementation, as well as the tests are migrated to .cljc to reuse as much code as possible. CLJS can be tested with `lein doo`.

The stress tests only run on the JVM and were extracted into a dedicated namespace.
The Travis config was changed to split the CLJ and CLJS test, as well as to trigger clojar deployments ony on master.

The Clojure version had to be bumped to 1.9 to get `swap-vals!` which is used for atomic popping from queues.

TODOs:
- [x] different namespace for interfaces in clj and cljs
- [x] migrate from Refs to Atoms
- [x] fix/adjust stress tests
- [x] cleanup & refactor, simplify cljc reader conditionals as far as possible